### PR TITLE
Add version file and validation

### DIFF
--- a/.github/workflows/AVC-VersionFileValidator.yml
+++ b/.github/workflows/AVC-VersionFileValidator.yml
@@ -1,0 +1,19 @@
+name: Validate AVC .version files
+on:
+  push:
+  pull_request:
+    types:
+      - reopened
+      - synchronize
+      - reopened
+
+jobs:
+  validate_version_files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Validate files
+        uses: DasSkelett/AVC-VersionFileValidator@master

--- a/KerwisChineseAerospacePack.version
+++ b/KerwisChineseAerospacePack.version
@@ -1,0 +1,17 @@
+{
+    "NAME": "Kerwis Chinese Aerospace Pack",
+    "URL": "https://github.com/Industrial-Pigeon-and-Magic/KerwisChineseAerospacePack/raw/main/KerwisChineseAerospacePack.version",
+    "DOWNLOAD": "https://spacedock.info/mod/2867/Kerwis%20Chinese%20Aerospace%20Pack/download/1.1",
+    "VERSION": {
+        "MAJOR": 1,
+        "MINOR": 1
+    },
+    "KSP_VERSION_MIN": {
+        "MAJOR": 1,
+        "MINOR": 8
+    },
+    "KSP_VERSION_MAX": {
+        "MAJOR": 1,
+        "MINOR": 12
+    }
+}


### PR DESCRIPTION
Hi @Veloctor!

@Icecovery has been helping the CKAN team to maintain this mod's compatibility manually (see KSP-CKAN/NetKAN#8794, KSP-CKAN/NetKAN#8823, KSP-CKAN/NetKAN#8867, and KSP-CKAN/NetKAN#8941). This is not optimal because it is a manual step, so the compatibility of each release is limited when it is first released until someone notices it and creates an update to fix it.

If you merge this pull request and include an up to date copy of the `KerwisChineseAerospacePack.version` file in your release ZIP files, then we will be able to use it to set the compatibility automatically to the range of game versions that you choose in the `KSP_VERSION_MIN` and `KSP_VERSION_MAX` properties.

This pull request also includes a GitHub workflow to validate changes to the version file as they are made using @DasSkelett's GitHub Action, to help catch syntax errors and other problems before you create the release ZIPs.

Cheers!
